### PR TITLE
chore: update to dila api 1.8.4

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -26,6 +26,8 @@ jobs:
         env:
           OAUTH_CLIENT_ID: ${{ secrets.DILA_OAUTH_CLIENT_ID }}
           OAUTH_CLIENT_SECRET: ${{ secrets.DILA_OAUTH_CLIENT_SECRET }}
+          API_HOST: "https://api.piste.gouv.fr/dila/legifrance/lf-engine-app"
+          TOKEN_HOST: "https://oauth.piste.gouv.fr/api/oauth/token"
 
       - name: Get metadata
         id: metadata

--- a/scripts/libs/api.js
+++ b/scripts/libs/api.js
@@ -7,8 +7,8 @@ export async function getTableMatieres({ date = Date.now(), textId, sctId }) {
   return await dilaApi
     .fetch({
       method: "POST",
-      params: { date, sctId, textId },
-      path: "consult/code/tableMatieres",
+      params: { date, sctId, textId, nature: "CODE" },
+      path: "consult/legi/tableMatieres",
     })
     .then(checkApiResponse);
 }


### PR DESCRIPTION
 - upgrade `tableMatieres` endpoint url
 - updates hosts in fetch workflow